### PR TITLE
(Quick Fix) "Bad Pixmap" Errors due to underflow occurring.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -71,6 +71,7 @@ endif
 ifeq ($(CFLAGS), $(DEBUG)) 
 	CMACROS += -DENABLE_DEBUG 
 	CMACROS += -DXCB_TRL_ENABLE_DEBUG
+	CMACROS += -DXINERAMA
 endif
 
 # Linker flags

--- a/dwm.h
+++ b/dwm.h
@@ -219,13 +219,15 @@ struct Monitor
     int16_t by;                 /* Bar Y                                    */
     uint16_t bw;                /* Bar Width                                */
     uint16_t bh;                /* Bar Height                               */
+    XCBWindow root;             /* The Root window                          */
     XCBWindow barwin;           /* The managed status bar                   */
 };
 
 struct Layout
 {
-    const char *symbol;
+    char *symbol;
     void (*arrange)(Desktop *);
+    uint8_t pad0[16 + 32];      /* align for x64 */
 };
 
 struct Desktop
@@ -234,6 +236,7 @@ struct Desktop
     uint8_t layout;             /* The Layout Index             */
     uint8_t olayout;            /* The Previous Layout Index    */
 
+    Client *lastfocused;        /* Last focused client          */
     Client *clients;            /* First Client in linked list  */
     Client *clast;              /* Last Client in linked list   */
     Client *stack;              /* Client Stack Order           */
@@ -257,7 +260,6 @@ struct WM
     XCBDisplay *dpy;                /* The current display  */
     Monitor *selmon;                /* Selected Monitor     */
     Monitor *mons;                  /* Monitors             */
-    Client *lastfocused;            /* Last focused client  */
     XCBKeySymbols *syms;            /* keysym alloc         */
 };
 
@@ -269,7 +271,6 @@ struct CFG
     uint16_t nmaster;        /* number of clients in master area                                */
     uint16_t bw;             /* Default Border Width                                            */
     uint16_t bgw;            /* Default Border Gap Width                                        */
-
 
     uint16_t snap;           /* Window Resize/Move Snap to grid size                            */
     uint16_t rfrate;         /* max refresh rate when resizing, moving windows;  0 to disable   */
@@ -283,8 +284,9 @@ struct CFG
 };
 
 void argcvhandler(int argc, char *argv[]);
+void applysizechecks(Monitor *m, int32_t *x, int32_t *y, int32_t *width, int32_t *height, int32_t *border_width);
 void applygravity(uint32_t gravity, int16_t *x, int16_t *y, const uint16_t width, const uint16_t height, const uint16_t border_width);
-uint8_t applysizehints(Client *c, int16_t *x, int16_t *y, uint16_t *width, uint16_t *height, uint8_t interact);
+uint8_t applysizehints(Client *c, int32_t *x, int32_t *y, int32_t *width, int32_t *height, uint8_t interact);
 void arrange(Desktop *desk);
 void arrangemon(Monitor *m);
 void arrangemons(void);
@@ -332,7 +334,7 @@ Client *nextvisible(Client *c);
 Client *lastvisible(Client *c);
 void quit(void);
 Monitor *recttomon(int16_t x, int16_t y, uint16_t width, uint16_t height);
-void resize(Client *c, int16_t x, int16_t y, uint16_t width, uint16_t height, uint8_t interact);
+void resize(Client *c, int32_t x, int32_t y, int32_t width, int32_t height, uint8_t interact);
 void resizeclient(Client *c, int16_t x, int16_t y, uint16_t width, uint16_t height);
 void restack(Desktop *desk);
 void restart(void);

--- a/events.c
+++ b/events.c
@@ -785,12 +785,17 @@ configurenotify(XCBGenericEvent *event)
     {
         u8 dirty;
         dirty = (_wm.sw != w || _wm.sh != h);
+        
+        if(dirty)
+        {
+        }
+
         _wm.sw = w;
         _wm.sh = h;
 
 
         DEBUG("(w: %d, h: %d)", w, h);
-
+        return;
         if(updategeom() || dirty)
         {
             Monitor *m;
@@ -1199,7 +1204,7 @@ propertynotify(XCBGenericEvent *event)
     if(state == XCB_PROPERTY_DELETE)
     {   return;
     }
-
+    
     if((c = wintoclient(win)))
     {   
         XCBCookie cookie;

--- a/util.h
+++ b/util.h
@@ -34,16 +34,11 @@ typedef int64_t  i64;
                                     "\n", __FILE__,__LINE__,__func__,__VA_ARGS__); exit(EXIT_FAILURE); } while (0)
 #ifdef ENABLE_DEBUG
 #define DEBUG(fmt, ...) (fprintf(stderr, "[%s:%d] by %s(): " fmt "\n", __FILE__,__LINE__,__func__,__VA_ARGS__))
-#else
-#define DEBUG(fmt, ...) ((void)0)
-#endif
-
-#ifdef ENABLE_DEBUGGING
 #define DEBUG0(X) (fprintf(stderr, "[%s:%d] by %s(): " X "\n", __FILE__, __LINE__, __func__))
 #else
+#define DEBUG(fmt, ...) ((void)0)
 #define DEBUG0(X) ((void)0)
 #endif
-
 
 /* gcc */
 #define ASM(X)                          (__asm__(X))


### PR DESCRIPTION
If the border width was bigger than the height/width that we specified, we would overflow/underflow.

This only occured in the tile layout as the grid layout would need more than 256 clients or a very small screen to occur.