### PR TITLE
Fixed Below stack priority being ignored

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -3342,16 +3342,23 @@ specialconds(int argc, char *argv[])
 
 /* how to return.
  * reference point is c1.
- * so if c1 has higher priority return 1.
  *
- * so return 1 if x1 > x2;
- * return 0 if x1 <= x2
  * sort order is 1,2,3,4,5,6
  */
 static int
-__stack_priority_helper(int32_t x1, int32_t x2)
+__stack_priority_helper_above(unsigned int x1, unsigned int x2)
 {
     return x1 < x2;
+}
+/* how to return.
+ * reference point is c1.
+ *
+ * sort order is 6,5,4,3,2,1
+ */
+static int 
+__stack_priority_helper_below(unsigned int x1, unsigned int x2)
+{
+    return x1 > x2;
 }
 
 int
@@ -3372,35 +3379,37 @@ stackpriority(Client *c1, Client *c2)
     const unsigned int hidden1 = ISHIDDEN(c1);
     const unsigned int hidden2 = ISHIDDEN(c2);
 
-    if(dock1 ^ dock2)
-    {   
-        DEBUG0("DOCK");
-        return __stack_priority_helper(dock1, dock2);
-    }
-    else if(above1 ^ above2)
-    {   
-        DEBUG0("ABOVE");
-        return __stack_priority_helper(above1, above2);
-    }
-    else if(float1 ^ float2)
-    {   
-        DEBUG0("FLOAT");
-        return __stack_priority_helper(float1, float2);
-    }
-    else if(below1 ^ below2)
+    /* Bottom Restacking */
+    if(below1 ^ below2)
     {   
         DEBUG0("BELOW");
-        return __stack_priority_helper(below1, below2);
+        return __stack_priority_helper_below(below1, below2);
     }
     else if(hidden1 ^ hidden2)
     {   
         DEBUG0("HIDDEN");
-        return __stack_priority_helper(hidden1, hidden2);
+        return __stack_priority_helper_below(hidden1, hidden2);
+    }
+    /* Regular restacking */
+    else if(dock1 ^ dock2)
+    {   
+        DEBUG0("DOCK");
+        return __stack_priority_helper_above(dock1, dock2);
+    }
+    else if(above1 ^ above2)
+    {   
+        DEBUG0("ABOVE");
+        return __stack_priority_helper_above(above1, above2);
+    }
+    else if(float1 ^ float2)
+    {   
+        DEBUG0("FLOAT");
+        return __stack_priority_helper_above(float1, float2);
     }
 
     DEBUG0("FOCUS");
     /* focus is forward order so, we must calculate reversely */
-    return __stack_priority_helper(c2->rstacknum, c1->rstacknum);
+    return __stack_priority_helper_above(c2->rstacknum, c1->rstacknum);
 }
 
 void


### PR DESCRIPTION
Some applications like conky, still dont work well even after this fix, but this should fix base apps like conky that wanted to be "below" still be below
Refer to: NetWMStateBelow