### PR TITLE
Fixed Restack configurequests breaking window properties

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -2240,8 +2240,10 @@ void
 resizeclient(Client *c, int16_t x, int16_t y, uint16_t width, uint16_t height)
 {
     u32 mask = 0;
+
     if(c->x != x)
-    {   c->oldx = c->x;
+    {   
+        c->oldx = c->x;
         c->x = x;
         mask |= XCB_CONFIG_WINDOW_X;
     }
@@ -2269,7 +2271,6 @@ resizeclient(Client *c, int16_t x, int16_t y, uint16_t width, uint16_t height)
         .y = y,
         .width = width,
         .height = height,
-        .border_width = c->bw
     };
     XCBConfigureWindow(_wm.dpy, c->win, mask, &changes);
     configure(c);
@@ -2662,6 +2663,7 @@ setborderwidth(Client *c, uint16_t border_width)
         c->oldbw = c->bw;
         c->bw = border_width;
         XCBSetWindowBorderWidth(_wm.dpy, c->win, c->bw);
+        configure(c);
     }
 }
 

--- a/events.c
+++ b/events.c
@@ -629,32 +629,38 @@ configurerequest(XCBGenericEvent *event)
     Client *c;
     u8 sync = 0;
     u8 restack = 0;
+    u8 geom = 0;
     if((c = wintoclient(win)))
     {
         const Monitor *m = c->desktop->mon;
         if(mask & XCB_CONFIG_WINDOW_BORDER_WIDTH)
         {                           /* Border width should NEVER be bigger than the screen */
             setborderwidth(c, bw);
+            geom = 1;
         }
         if(mask & XCB_CONFIG_WINDOW_X)
         {
             c->oldx = c->x;
             c->x = m->mx + x;
+            geom = 1;
         }
         if(mask & XCB_CONFIG_WINDOW_Y)
         {
             c->oldy = c->y;
             c->y = m->my + y;
+            geom = 1;
         }
         if(mask & XCB_CONFIG_WINDOW_WIDTH)
         {
             c->oldw = c->w;
             c->w = w;
+            geom = 1;
         }
         if(mask & XCB_CONFIG_WINDOW_HEIGHT)
         {
             c->oldh = c->h;
             c->h = h;
+            geom = 1;
         }
         if(mask & XCB_CONFIG_WINDOW_STACK_MODE)
         {
@@ -769,20 +775,24 @@ configurerequest(XCBGenericEvent *event)
             }
             restack = 1;
         }
-        if((c->x + c->w) > m->mx + m->mw && ISFLOATING(c))
-        {   
-            c->oldx = c->x;
-            c->x = m->mx + ((m->mw >> 1) - (WIDTH(c) >> 1)); /* center in x direction */
-        }
-        if((c->y + c->h) > m->my + m->mh && ISFLOATING(c))
-        {   
-            c->oldy = c->y;
-            c->y = m->my + ((m->mh >> 1) - (HEIGHT(c) >> 1)); /* center in y direction */
-        }
-        /* these checks are so we maintain wasfloating correctly without messing everything up */
-        if(!ISFLOATING(c) && !DOCKED(c))
-        {   setfloating(c, 1);
-            restack = 1;
+        if(geom)
+        {
+            if((c->x + c->w) > m->mx + m->mw && ISFLOATING(c))
+            {   
+                c->oldx = c->x;
+                c->x = m->mx + ((m->mw >> 1) - (WIDTH(c) >> 1)); /* center in x direction */
+            }
+            if((c->y + c->h) > m->my + m->mh && ISFLOATING(c))
+            {   
+                c->oldy = c->y;
+                c->y = m->my + ((m->mh >> 1) - (HEIGHT(c) >> 1)); /* center in y direction */
+            }
+
+            /* these checks are so we maintain wasfloating correctly without messing everything up */
+            if(!ISFLOATING(c) && !DOCKED(c))
+            {   setfloating(c, 1);
+                restack = 1;
+            }
         }
 
         if(mask & (XCB_CONFIG_WINDOW_X|XCB_CONFIG_WINDOW_Y) && !(mask & (XCB_CONFIG_WINDOW_WIDTH|XCB_CONFIG_WINDOW_HEIGHT)))


### PR DESCRIPTION
Due to the fact that windows rarely ask for stuff (Raise/Lower) requests, this issue was not very prevalent.

Due to the fact that we recalculated the ISFLOATING(c) flag of a window this issue would occur even if they shouldnt.