### PR TITLE
Fixed segfault when managing new bar windows. managereply()

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -1771,7 +1771,7 @@ managereply(XCBWindow win, XCBCookie requests[MANAGE_CLIENT_COOKIE_COUNT])
 
     /* if its a new bar we dont want to return it as the monitor now manages it */
     if(!checknewbar(m, c, strut || strutp))
-    {   goto FAILURE;
+    {   c = NULL;
     }
     goto CLEANUP;
 FAILURE:


### PR DESCRIPTION
Even though we could still access the memory???? afterwards causing no errors (seems to be some glibc keeping the memory (cause we ask for memory offten)).

This was found after seeing segfaults on restoremonsesion().