### PR TITLE
Fixed bad access when accesing killed clients? maybe.

### DIFF
--- a/client.c
+++ b/client.c
@@ -604,7 +604,7 @@ focus(Client *c)
 {
     Monitor *selmon = _wm.selmon;
     Desktop *desk  = selmon->desksel;
-    if(!c || !ISVISIBLE(c))
+    if(!c || !ISVISIBLE(c) || NEVERHOLDFOCUS(c))
     {   for(c = startfocus(desk); c && !ISVISIBLE(c) && !KEEPFOCUS(c); c = nextfocus(c));
     }
     if(desk->sel && desk->sel != c)


### PR DESCRIPTION
Currently it seems that killing a barwin can cause bad access abort on debug builds, this issue is still unknown the root cause, this is a possible temporary fix.