### PR TITLE
Added Client Side Decorations (CSD) enabled by default.

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -1431,6 +1431,7 @@ startup(void)
     }
     PropInit();
     atexit(exithandler);
+    setenv("GTK_CSD", "amogus", 1);
 #ifndef DEBUG
     XCBSetErrorHandler(xerror);
 #endif


### PR DESCRIPTION
Until Server Sided Decorations are supported this will be in place, as a temporary fix to decorations.
Note that this option will be disable by default AFTER server sided decorations have been implemented