### PR TITLE
Fixed floating, Fixed underflow sizehints, Fixed queue not working.

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -9,7 +9,8 @@
 
 uint8_t
 __CQueue_full_no_lock(CQueue *queue)
-{   return (queue->front == queue->rear + 1) | ((!queue->front) & (queue->rear == (queue->datalen / (queue->datasize + !queue->datasize) - 1)));
+{   
+    return queue->front == queue->rear + 1 || (!queue->front && queue->rear == queue->datalen);
 }
 
 uint8_t 


### PR DESCRIPTION
- Floating windows now for the most part have their own designated states.
- Some windows (while still broken TODO) would underflow their values when applying size hints less than 0
- Fixed queue not correctly identifiying a FULL queue.