### PR TITLE
Added better desktop switch smoothing

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -263,7 +263,7 @@ setdesktopsel(Monitor *mon, Desktop *desksel)
         {
             if(desk != desksel)
             {
-                for(c = startstack(desk); c; c = nextstack(c))
+                for(c = laststack(desk); c; c = prevstack(c))
                 {   showhide(c);
                 }
             }


### PR DESCRIPTION
Sometimes X would flicker the windows, so instead of forward hiding, we backwards hide, so the last client flickered is the top most client, which should reduce visual flickering (But not actual flickering)