### PR TITLE
Fixed flickering when mapping new windows

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -228,6 +228,12 @@ Client *createclient(void);
  * NOTE: if NULL provided first visible client in stack is choosen as focus specifier.
  */
 void focus(Client *c);
+/* updates focus order to specified client, DOES NOT however, set X11 focus, only updates internal list.
+ * Which in turn desktop->sel IS NOT updated, and focus() MUST be called after.
+ * NOTE: This should NOT be used aside from manual visual optimizations.
+ * NOTE: if NULL provided first visible client in stack is choosen as focus specifier.
+ */
+Client *focusrealize(Client *c);
 /* Grabs a win buttons. 
  * Basically this just allows us to receive button press/release events from windows.
  */

--- a/src/client.c
+++ b/src/client.c
@@ -1089,27 +1089,15 @@ focus(Client *c)
 {
     Monitor *selmon = _wm.selmon;
     Desktop *desk  = selmon->desksel;
-    if(!c || !ISVISIBLE(c) || NEVERHOLDFOCUS(c))
-    {   for(c = startfocus(desk); c && !ISVISIBLE(c) && !KEEPFOCUS(c); c = nextfocus(c));
-    }
+    c = focusrealize(c);
     if(desk->sel && desk->sel != c)
     {   unfocus(desk->sel, 0);
     }
     if(c)
     {
-        if(c->desktop->mon != _wm.selmon)
-        {   _wm.selmon = c->desktop->mon;
-        }
-        if(c->desktop != _wm.selmon->desksel)
-        {   setdesktopsel(_wm.selmon, c->desktop);
-        }
-
         if(ISURGENT(c))
         {   seturgent(c, 0);
         }
-
-        detachfocus(c);
-        attachfocus(c);
 
         grabbuttons(c, 1);
         XCBSetWindowBorder(_wm.dpy, c->win, c->bcol);
@@ -1122,6 +1110,29 @@ focus(Client *c)
     }
     desk->sel = c;
     Debug("Focused: [%d]", c ? c->win : 0);
+}
+
+Client *
+focusrealize(Client *c)
+{
+    Monitor *selmon = _wm.selmon;
+    Desktop *desk  = selmon->desksel;
+    if(!c || !ISVISIBLE(c) || NEVERHOLDFOCUS(c))
+    {   for(c = startfocus(desk); c && !ISVISIBLE(c) && !KEEPFOCUS(c); c = nextfocus(c));
+    }
+    if(c)
+    {
+        if(c->desktop->mon != _wm.selmon)
+        {   _wm.selmon = c->desktop->mon;
+        }
+        if(c->desktop != _wm.selmon->desksel)
+        {   setdesktopsel(_wm.selmon, c->desktop);
+        }
+        detachfocus(c);
+        attachfocus(c);
+    }
+    Debug("Focus Realized: [%d]", c ? c->win : 0);
+    return c;
 }
 
 void

--- a/src/events.c
+++ b/src/events.c
@@ -837,9 +837,6 @@ maprequest(XCBGenericEvent *event)
 
     u8 sync = 0;
 
-    /* map window first (illusion of responsiveness) */
-    sync = 1;
-    XCBMapWindow(_wm.dpy, win);
     PropListen(_wm.handler, _wm.dpy, win, PropManage);
 
     if(sync)

--- a/src/prop.c
+++ b/src/prop.c
@@ -433,6 +433,7 @@ PropUpdateManage(
 {
     const XCBWindow win = cookie->win;
     Client *c;
+    Client *cf = NULL;     /* client focus */
     XCBCookie requests[ManageClientLAST];
     void *replies[ManageClientLAST];
 
@@ -444,14 +445,17 @@ PropUpdateManage(
     c = manage(win, replies);
     if(c)
     {
-        focus(c);
+        cf = focusrealize(c);
         arrange(c->desktop);
     }
     else if(_wm.selmon->bar && _wm.selmon->bar->win == win)
     {
-        focus(NULL);
+        cf = focusrealize(NULL);
         arrange(_wm.selmon->desksel);
     }
+    XCBMapWindow(_wm.dpy, win);
+    focus(cf);
+
     XCBFlush(_wm.dpy);
     UnlockMainThread();
     managecleanup(replies);


### PR DESCRIPTION
Floating windows would face this problem due to restacking occurring AFTER mapping the window.
This however doesnt fix general window flicker, it does reduce it though.