### PR TITLE
Fixed early return when not suppose to happen in events.c, propertynotify()

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -1566,8 +1566,11 @@ propertynotify(XCBGenericEvent *event)
             else if(atom == netatom[NetWMIcon])
             {   type = PropIcon;
             }
-            /* not found return */
-            return;
+            else
+            {
+                /* not found return */
+                return;
+            }
     }
     /* encase we fuck up later down the line */
     if(type == PropNone || type >= PropLAST)


### PR DESCRIPTION
This explains alot actually, and might break alot of stuff, maybe