### PR TITLE
Fixed improper thread handling

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -2416,8 +2416,7 @@ __update_motif_decor(Client *c, uint32_t hints)
     }
     if(hints & DECOR_RESIZEH)
     {   
-        /* NOP */
-        ASSUME(0);
+        (void)hints;
     }
     if(hints & DECOR_TITLE)
     {   setshowdecor(c, 1);
@@ -2426,14 +2425,10 @@ __update_motif_decor(Client *c, uint32_t hints)
     {   setshowdecor(c, 0);
     }
     if(hints & DECOR_MENU)
-    {  
-        /* NOP */
-        ASSUME(0);
+    {   (void)hints;
     }
     if(hints & DECOR_MINIMIZE || hints & DECOR_MAXIMIZE)
-    {   
-        /* NOP */
-        ASSUME(0);
+    {   (void)hints;
     }
 }
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -121,7 +121,9 @@ CQueueAdd(CQueue *queue, void *data)
     queue->rear = index;
 
     memcpy((uint8_t *)queue->data + queue->datasize * index, data, queue->datasize);
+    pthread_mutex_lock(&queue->condmutex);
     pthread_cond_signal(&queue->cond);
+    pthread_mutex_unlock(&queue->condmutex);
     CQueueUnlockW(queue);
     return 1;
 }

--- a/tools/XCB-TRL/__private__xcb__err__.c
+++ b/tools/XCB-TRL/__private__xcb__err__.c
@@ -17,7 +17,7 @@ static khash_t(__KHASH__ERROR__FUNCTIONS__) *_hashed_functions = NULL;
 static khash_t(__KHASH__ERROR__LOGS__) *_hashed_logs = NULL;
 
 /* khash is not thread safe */
-static pthread_rwlock_t _khash_mutex = PTHREAD_RWLOCK_INITIALIZER;
+static pthread_mutex_t _khash_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #endif
 
@@ -158,6 +158,32 @@ __XCBSetErrorHandler(
     }
 }
 
+/* atexit() is not multithreaded */
+void 
+__atexit_xcb_handler(void)
+{
+#ifdef XCB_TRL_ENABLE_DEBUG
+
+    if(_hashed_logs)
+    {   kh_destroy(__KHASH__ERROR__LOGS__, _hashed_logs);
+    }
+
+    if(_hashed_functions)
+    {   kh_destroy(__KHASH__ERROR__FUNCTIONS__, _hashed_functions);
+    }
+
+    _hashed_logs = NULL;
+    _hashed_functions = NULL;
+
+    /* ensure no deadlocks occur */
+
+    int ret = pthread_mutex_trylock(&_khash_mutex);
+    pthread_mutex_unlock(&_khash_mutex);
+
+    (void)ret;
+#endif
+}
+
 void 
 _xcb_handler(
         xcb_connection_t *display, 
@@ -169,7 +195,11 @@ _xcb_handler(
     uint32_t sequence = error->sequence;
     khint_t k;
 
-    pthread_rwlock_rdlock(&_khash_mutex);
+    pthread_mutex_lock(&_khash_mutex);
+
+    if(!_hashed_logs || !_hashed_functions)
+    {   goto UNLOCK;
+    }
 
     k = kh_get(__KHASH__ERROR__LOGS__, _hashed_logs, sequence);
 
@@ -182,7 +212,7 @@ _xcb_handler(
     _XCB_MANUAL_DEBUG("%s", kh_key(_hashed_functions, k));
 
 UNLOCK:
-    pthread_rwlock_unlock(&_khash_mutex);
+    pthread_mutex_unlock(&_khash_mutex);
 #endif
     XCBBreakPoint();
 }
@@ -213,16 +243,33 @@ XCBDebugPushID(
 {
 #ifdef XCB_TRL_ENABLE_DEBUG
 
-    pthread_rwlock_wrlock(&_khash_mutex);
+    /* Due to this being an implementation detail we can push this later down development,
+     * Anayways we ignore 0 sequences as they are technically not implemented yet,
+     * if they were implemented then we would just use the function_name as a call stack order
+     * rather than the sequence of 0, but we removed call stack backtrace since last major release.
+     */
+    if(!sequence)
+    {   return;
+    }
+
+    pthread_mutex_lock(&_khash_mutex);
 
     if(!_hashed_logs)
-    {   _hashed_logs = kh_init(__KHASH__ERROR__LOGS__);
+    {   
+        _hashed_logs = kh_init(__KHASH__ERROR__LOGS__);
+        if(_hashed_logs)
+        {   
+            /* this could fail but would only result in memory leak which isnt that important */
+            int status = atexit(__atexit_xcb_handler);
+
+            if(unlikely(status))
+            {   fprintf(stderr, "XCB error handler failed to set atexit(), this may result in a MEMORY_LEAK\n");
+            }
+        }
     }
 
     if(!_hashed_logs)
-    {  
-        goto UNLOCK;
-        return;
+    {   goto UNLOCK;
     }
 
     if(!_hashed_functions)
@@ -230,9 +277,7 @@ XCBDebugPushID(
     }
 
     if(!_hashed_functions)
-    {   
-        goto UNLOCK;
-        return;
+    {   goto UNLOCK;
     }
 
     enum
@@ -252,9 +297,7 @@ XCBDebugPushID(
         k = kh_put(__KHASH__ERROR__FUNCTIONS__, _hashed_functions, function_name, &err);
         /* Failed to add function */
         if(err == __KHASH_BAD_OPERATION)
-        {   
-            goto UNLOCK;
-            return;
+        {   goto UNLOCK;
         }
     }
 
@@ -271,7 +314,6 @@ XCBDebugPushID(
     {   kh_value(_hashed_logs, k) = func_it;
     }
 UNLOCK:
-    pthread_rwlock_unlock(&_khash_mutex);
+    pthread_mutex_unlock(&_khash_mutex);
 #endif
-    
 }

--- a/tools/XCB-TRL/__private__xcb__err__.h
+++ b/tools/XCB-TRL/__private__xcb__err__.h
@@ -11,9 +11,9 @@ extern "C" {
 #include "safebool.h"
 
 #ifdef XCB_TRL_ENABLE_DEBUG
-    #define _xcb_push_func(cookie) XCBDebugPushID(__func__, cookie.sequence)
+    #define _xcb_push_func(XCB_PUSH_COOKIE) XCBDebugPushID(__func__, XCB_PUSH_COOKIE.sequence)
 #else
-    #define _xcb_push_func(cookie) ((void)cookie)
+    #define _xcb_push_func(XCB_PUSH_COOKIE) ((void)XCB_PUSH_COOKIE)
 #endif
 
 

--- a/tools/XCB-TRL/xcb_trl.c
+++ b/tools/XCB-TRL/xcb_trl.c
@@ -117,7 +117,6 @@ XCBOpenDisplay(
     XCBCookie ck = { .sequence = 0 };
     _xcb_push_func(ck);
 
-
     if(!display || xcb_connection_has_error(display))
     {   
 
@@ -279,7 +278,7 @@ XCBVendorRelease(
     XCBCookie ret = { .sequence = 0 };
     _xcb_push_func(ret);
 
-    return xcb_get_setup (display)->release_number;
+    return xcb_get_setup(display)->release_number;
 }
 
 int


### PR DESCRIPTION
Fixed XCB improper debug handling resulting in deadlock, improper cond holding in queue.c, and removed ASSUME(0) in some functions due to changes made resulting in ABORT due to 'unexpected location reached` instead of NOP