### PR TITLE
Updated makefile for architecture as a option, dropped support for MaxCC

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -44,15 +44,17 @@ PRELINKERFLAGS ?= -fpie -fstack-protector-strong -fstack-clash-protection ${LINK
 INLINELIMIT ?= 15
 # can conflict with adress sanatizer if used (clang)
 NO_SANATIZE_FLAGS =  -Wl,-z,relro
-
+X86 = -m32
+X86_64 = -m64
+BUILD_ARCHITECTURE = ${X86_64}
 LINKLIBS = -lpthread -lm
-LINKFLAGS = ${LINKMODE} -Wl,--as-needed,--relax,-z,now,-z,noexecstack,-z,defs,-pie -finline-limit=${INLINELIMIT}  ${LINKTIMEOPTIMIZATIONS} ${LINKLIBS}
+LINKFLAGS = ${LINKMODE} -Wl,--as-needed,--relax,-z,now,-z,noexecstack,-z,defs,-pie -finline-limit=${INLINELIMIT}  ${LINKTIMEOPTIMIZATIONS} ${LINKLIBS} ${BUILD_ARCHITECTURE}
 LINKRELEASE = ${NO_SANATIZE_FLAGS} 
 #-Wl,--strip-all 
 LINKDEBUG = -Wl,--gc-sections ${MEMFLAGS}
 
 CPPFLAGS = -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L ${XINERAMAFLAGS}
-CCFLAGS  = ${CCVERSION} ${WARNINGFLAGS} ${INCS} ${CPPFLAGS} ${PRELINKERFLAGS} 
+CCFLAGS  = ${CCVERSION} ${WARNINGFLAGS} ${INCS} ${CPPFLAGS} ${PRELINKERFLAGS} ${BUILD_ARCHITECTURE}
 RELEASEFLAGS = ${CCFLAGS} 
 
 DEBUG 	= -ggdb -g ${SECTIONCODE} ${MEMFLAGS} -fverbose-asm -O0

--- a/include/settings.h
+++ b/include/settings.h
@@ -69,8 +69,6 @@ UserSettings
     uint16_t Snap;          /* snap window to border in pixels; 0 to disable (NOT RECOMMENDED)  */
     uint16_t RefreshRate;   /* max refresh rate when resizing, moving windows;  0 to disable    */
 
-    uint16_t MaxCC;         /* max number of clients (XOrg Default is 256)                      */
-
     /* Not bool or bitfield for portability */
     uint8_t HoverFocus;
     uint8_t UseDecorations;
@@ -124,15 +122,11 @@ enum
     MCount,
     Snap,
     RefreshRate,
-    MaxCC,
-
 
     HoverFocus,
     UseDecorations,
     UseClientSideDecorations,
     PreferClientSideDecorations,
-
-
 
     BarLX,
     BarLY,

--- a/src/client.c
+++ b/src/client.c
@@ -1278,7 +1278,7 @@ manage(XCBWindow win, void *replies[ManageClientLAST])
         Debug("Cannot manage(): [%u]", win);
         goto FAILURE;
     }
-    
+
     const u16 bw = 0;
     const u32 bcol = 0;
     const u8 showdecor = 1;

--- a/src/settings.c
+++ b/src/settings.c
@@ -28,7 +28,6 @@ __USER__SETTINGS__DATA__[] =
     VOX_ADD_MEMBER_SETTING(MCount, SCTypeUSHORT, 1)
     VOX_ADD_MEMBER_SETTING(Snap, SCTypeUSHORT, 10)
     VOX_ADD_MEMBER_SETTING(RefreshRate, SCTypeUSHORT, 60)
-    VOX_ADD_MEMBER_SETTING(MaxCC, SCTypeUSHORT, 256)
 
     /* BOOL Types */
     VOX_ADD_MEMBER_SETTING(HoverFocus, SCTypeBOOL, false)
@@ -210,8 +209,6 @@ USLoad(
                    Debug("%d", _cfg.MCount);
                    Debug("%d", _cfg.Snap);
                    Debug("%d", _cfg.RefreshRate);
-
-                   Debug("%d", _cfg.MaxCC);
 
                    Debug("%s", GET_BOOL(_cfg.HoverFocus));
                    Debug("%s", GET_BOOL(_cfg.UseDecorations));


### PR DESCRIPTION
+ Make file can now set architecture as build, X86 still not supported but plans to, maybe?
+ Officially dropped support for config setting MaxCC, old configs still work. But MaxCC no longer works, not that it did to begin with.