### PR TITLE
Bug Fixes

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -204,6 +204,8 @@ void NonNull clientinitfloat(Client *c);
 /* Initializes the Client geometry from the specified XCBWindowGeometry struct. 
  */
 void NonNullArg(1) clientinitgeom(Client *c, XCBWindowGeometry *geometry);
+/*Initializes the Client window map state, and map iconic states. */
+void NonNullArg(1) clientinitmapstate(Client *c, XCBGetWindowAttributes *wa);
 /* Initializes the Client window type from the specified XCBWindowProperty. */
 void NonNullArg(1) clientinitwtype(Client *c, XCBWindowProperty *windowtypereply);
 /* Initializes the Client window state from the specified XCBWindowProperty. */
@@ -575,8 +577,9 @@ uint32_t NonNull NEVERFOCUS(Client *c);
 /* client state */
 uint32_t NonNull NEVERHOLDFOCUS(Client *c);
 uint32_t NonNull ISVISIBLE(Client *c);
-/* TODO: XServer race conditions makes this unsuitable for usage */
- __DEPRECATED__ uint32_t NonNull ISMAPPED(Client *c); 
+/* 
+ */
+uint32_t NonNull ISMAPPED(Client *c); 
 uint32_t NonNull SHOWDECOR(Client *c);
 uint32_t NonNull ISSELECTED(Client *c);
 

--- a/include/settings.h
+++ b/include/settings.h
@@ -39,6 +39,8 @@
             .default_data = VOX_ADD_MEMBER_TYPED(TYPE, DEFAULT_SETTING) \
         },
 
+#define VOX_ADD_MEMBER_SETTING(NAME, TYPE, DEFAULT_SETTING) \
+        VOX_ADD_MEMBER(NAME, TYPE, offsetof(UserSettings, NAME), FIELD_SIZEOF(UserSettings, NAME), DEFAULT_SETTING)
 
 
 /* User Settings Flags */

--- a/src/argcv.c
+++ b/src/argcv.c
@@ -132,27 +132,44 @@ ArgcvDisplayCompilerInfo(
         void
         )
 {
-    char *compiler;
+    char *compiler = "UNKNOWN";
+    char *timestamp = "TimeStamp Not Available";
     short majorversion = -1;
     short minorversion = -1;
     short patchversion = -1;
-    compiler = "UNKNOWN";
+    int byteorder = GET_BYTE_ORDER();
+    int pointersize = sizeof(void *);
+
 #if defined(__GNUC__)
+    (void)compiler;
+    (void)timestamp;
+
     compiler = "GCC";
+    timestamp = __TIMESTAMP__;
     majorversion = __GNUC__;
     minorversion = __GNUC_MINOR__;
     patchversion = __GNUC_PATCHLEVEL__;
+    pointersize = __SIZEOF_POINTER__;
 #elif defined(__clang__)
+    (void)compiler;
+    (void)timestamp;
+
     compiler = "clang";
+    timestamp = __TIMESTAMP__;
     majorversion = __clang_major__;
     minorversion = __clang_minor__;
     patchversion = __clang_patchlevel__;
+    pointersize = __SIZEOF_POINTER__;
 #elif defined(_MSC_VER)
+    (void)compiler;
+
     compiler = "MSVC";
     majorversion = _MSC_VER;
     minorversion = 0;
     patchversion = 0;
 #elif defined(__INTEL__COMPILER)
+    (void)compiler;
+
     compiler = "INTEL";
     majorversion = __INTEL_COMPILER;
     minorversion = 0;
@@ -181,8 +198,9 @@ ArgcvDisplayCompilerInfo(
 
     printf( "Compiler Information.\n"
             "  Compiled:        %s %s\n"
+            "  Timestamp:       %s\n"
             "  Compiler:        [%s v%d.%d.%d]\n" 
-            "  STDC:            [%d] [%lu]\n"
+            "  STDC:            [%d] [%d] [%lu]\n"
             "  BYTE_ORDER:      [%d]\n"
             "  POINTER_SIZE:    [%d]\n"
             "Version Information.\n"
@@ -191,10 +209,11 @@ ArgcvDisplayCompilerInfo(
             ,
             /* TODO __DATE__ has an extra space for some reason? */ 
             date, __TIME__,
+            timestamp,
             compiler, majorversion, minorversion, patchversion,
-            __STDC_HOSTED__, __STDC_VERSION__,
-            __BYTE_ORDER__,
-            __SIZEOF_POINTER__,
+            __STDC__, __STDC_HOSTED__, __STDC_VERSION__,
+            byteorder,
+            pointersize,
             VERSION,
             MARK
           );

--- a/src/client.c
+++ b/src/client.c
@@ -480,7 +480,7 @@ u32 NEVERFOCUS(Client *c)       { return c->ewmhflags & WStateFlagNeverFocus; }
 u32 NEVERHOLDFOCUS(Client *c)   { return NEVERFOCUS(c) || ISDOCK(c);}
 u32 ISMAXHORZ(Client *c)        { return WIDTH(c) == c->desktop->mon->ww; }
 u32 ISMAXVERT(Client *c)        { return HEIGHT(c) == c->desktop->mon->wh; }
-u32 ISVISIBLE(Client *c)        { return (c->desktop->mon->desksel == c->desktop || ISSTICKY(c)) && !(ISHIDDEN(c) || ISMAPICONIC(c)); }
+u32 ISVISIBLE(Client *c)        { return (c->desktop->mon->desksel == c->desktop || ISSTICKY(c)) && !(ISHIDDEN(c) || ISMAPICONIC(c) || !ISMAPPED(c)); }
 
 u32 ISMAPPED(Client *c)         { return c->flags & ClientFlagMapped; }
 u32 SHOWDECOR(Client *c)        { return c->flags & ClientFlagShowDecor; }
@@ -541,35 +541,10 @@ u32 CANMANAGE(XCBWindow win, XCBGetWindowAttributes *waattributes, XCBWindowProp
 
                     if(waattributes && waattributes->override_redirect)
                     {
-                        /* theoredically we could manage these but they are a hastle to deal with */
                         if(waattributes->override_redirect)
                         {
-                            //Debug("Override Redirect: [%d]", win);
+                            Debug("Override Redirect: [%d]", win);
                             goto NO_MANAGE;
-                        }
-                        switch(waattributes->map_state)
-                        {
-                            case XCB_MAP_STATE_VIEWABLE:
-                                break;
-                            case XCB_MAP_STATE_UNVIEWABLE:
-                            case XCB_MAP_STATE_UNMAPPED:
-                            default:
-                                /* if the window is 'iconic' we dont handle that as of vox-wm v3.2.0, so we just treat as normal window */
-                                if(wastate)
-                                {
-                                    if(status == NO_FORMAT)
-                                    {   goto NO_MANAGE;
-                                    }
-
-                                    if(size != sizeof(u32))
-                                    {   Debug("Format is incorrect while processing WMState for [%d]", win);
-                                    }
-
-                                    if(data && *data != XCB_ICCCM_WM_STATE_ICONIC)
-                                    {   goto NO_MANAGE;
-                                    }
-                                }
-                                goto NO_MANAGE;
                         }
                     }
 
@@ -801,6 +776,32 @@ clientinitgeom(Client *c, XCBWindowGeometry *wg)
         /* if no specified border width default to our own. */
         if(wg->border_width)
         {   c->bw = wg->border_width;
+        }
+    }
+}
+
+void 
+clientinitmapstate(Client *c, XCBGetWindowAttributes *wa)
+{
+    if(wa)
+    {
+        switch(wa->map_state)
+        {
+            case XCBIsViewable:
+                setmapstate(c, WMMapStateMapped);
+                setwtypemapnormal(c, 1);
+                break;
+            /* Unviewable is when parent is unmapped, but implementation wise we can treat this as unmapped.
+             * as there is no real difference in terms of error generated from certain operations...
+             * and this isnt particulary useful regardless...
+             */
+            case XCBIsUnviewable:
+            case XCBIsUnmapped:
+            default:
+                setwtypemapiconic(c, 1);
+
+                setmapstate(c, WMMapStateUnmapped);
+                break;
         }
     }
 }
@@ -1344,6 +1345,7 @@ manage(XCBWindow win, void *replies[ManageClientLAST])
     /* check if should be floating after, all size hints and other things are set. */
     clientinitfloat(c);
     clientinitdecor(c);
+    clientinitmapstate(c, waattributes);
     XCBSelectInput(_wm.dpy, win, inputmask);
     grabbuttons(c, 0);
 
@@ -1916,10 +1918,16 @@ setfloating(Client *c, uint8_t state)
 void
 setfocus(Client *c)
 {
+    if(!ISMAPPED(c))
+    {   
+        Debug0("unmapped windows cannot set their focus....");
+        return;
+    }
+
     if(HASWMTAKEFOCUS(c))
     {   sendprotocolevent(c, wmatom[WMTakeFocus]);
-    
     }
+
     if(!NEVERHOLDFOCUS(c))
     {
         XCBSetInputFocus(_wm.dpy, c->win, XCB_INPUT_FOCUS_POINTER_ROOT, XCB_CURRENT_TIME);
@@ -2051,8 +2059,10 @@ unfocus(Client *c, uint8_t setfocus)
 
     if(setfocus)
     {   
+        XCBWindow noactivewindow = XCB_NONE;
+
         XCBSetInputFocus(_wm.dpy, _wm.root, XCB_INPUT_FOCUS_POINTER_ROOT, XCB_CURRENT_TIME);
-        XCBDeleteProperty(_wm.dpy, _wm.root, netatom[NetActiveWindow]);
+        XCBChangeProperty(_wm.dpy, _wm.root, netatom[NetActiveWindow], XCB_ATOM_WINDOW, 32, XCB_PROP_MODE_REPLACE, &noactivewindow, 1);
     }
 
     SETFLAG(c->ewmhflags, WStateFlagFocused, 0);
@@ -2091,15 +2101,17 @@ unmanage(Client *c, uint8_t destroyed)
 
     /* prevent dangling pointer here woops */
     if(!destroyed)
-    {   
+    {   grabbuttons(c, ISFOCUSED(c));
         /* TODO causes alot of errors for some reason even if its not "destroyed" */
     }
+
     delclienthash(c);
     detachcompletely(c);
     /* Destroy colormap */
     updatecolormap(c, 0);
     updateclientlist(win, ClientListRemove);
     cleanupclient(c);
+
     Debug("Unmanaged: [%u]", win);
 }
 

--- a/src/decorations.c
+++ b/src/decorations.c
@@ -5,6 +5,24 @@
 
 #define _DECOR_FLAGS_PREFER_CSD_    (1 << 0)
 
+
+Decoration *
+createdecoration(void)
+{
+    Decoration *decor = malloc(sizeof(*decor));
+
+    if(decor)
+    {
+        decor->w = 1;
+        decor->h = 1;
+        decor->win = 0;
+        decor->child = 0;
+        decor->flags = 0;
+    }
+
+    return decor;
+}
+
 Decoration *
 X11DecorCreate(void)
 {

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -397,14 +397,16 @@ restack(Desktop *desk)
     desk->rlast = desk->slast;
 
     slist = laststack(desk);
+
     /* reset client list */
     if(slist)
-    {   XCBChangeProperty(_wm.dpy, _wm.root, netatom[NetClientListStacking], XCB_ATOM_WINDOW, 32, XCB_PROP_MODE_REPLACE, (unsigned char *)&slist->win, 1);
+    {   
+        XCBChangeProperty(_wm.dpy, _wm.root, netatom[NetClientListStacking], XCB_ATOM_WINDOW, 32, XCB_PROP_MODE_REPLACE, (unsigned char *)&slist->win, 1);
     }
     else
     {   
         winstack[0] = 0;
-        XCBChangeProperty(_wm.dpy, _wm.root, netatom[NetClientListStacking], XCB_ATOM_WINDOW, 32, XCB_PROP_MODE_REPLACE, winstack, 1);
+        XCBChangeProperty(_wm.dpy, _wm.root, netatom[NetClientListStacking], XCB_ATOM_WINDOW, 32, XCB_PROP_MODE_REPLACE, winstack, 0);
     }
 
     for(slist = prevstack(slist); slist; slist = prevstack(slist))

--- a/src/events.c
+++ b/src/events.c
@@ -982,7 +982,9 @@ destroynotify(XCBGenericEvent *event)
     {   
         u32 sticky = ISSTICKY(c);
         Desktop *desk = c->desktop;
+
         unmanage(c, 1);
+
         /* if desktop was selected re arrange (no need to waste resources if not visbile) */
         if(desk->mon->desksel == desk || sticky)
         {
@@ -1070,20 +1072,21 @@ unmapnotify(XCBGenericEvent *event)
     if(isconfigure)
     {   
         Debug0("Window unmapped, but will be remaped, AKA: FROM_CONFIGURE");
-
-        if(c)
-        {   setmapstate(c, WMMapStateUnmapped);
-        }
-
         return;
     }
 
     if(c)
-    {   
-
+    {  
         u32 sticky = ISSTICKY(c);
         Desktop *desk = c->desktop;
-        unmanage(c, 1);
+
+        setmapstate(c, WMMapStateUnmapped);
+
+        /* currently decorations are kinda not implemented */
+        if(!_cfg.UseDecorations || 1)
+        {   unmanage(c, 1);
+        }
+
         /* if desktop was selected re arrange (no need to waste resources if not visbile) */
         if(desk->mon->desksel == desk || sticky)
         {

--- a/src/main.c
+++ b/src/main.c
@@ -911,6 +911,9 @@ scan(void)
                 index = i * ManageClientLAST;
                 managerequest(wins[i], managecookies + index);
             }
+
+            /* flush request buffer */
+            XCBFlush(_wm.dpy);
             
             uint8_t hastrans = 0;
             /* get them replies back */
@@ -1378,9 +1381,7 @@ startup(void)
     startupwm();
     checkotherwm();
     atexit(exithandler);
-#ifndef Debug
     XCBSetErrorHandler(xerror);
-#endif
 }
 
 void
@@ -1446,9 +1447,9 @@ void
 xerror(XCBDisplay *display, XCBGenericError *err)
 {
     if(likely(err))
-    {   
-#if NDEBUG
+    {
         DebugI("%s %s\n", XCBGetErrorMajorCodeText(err->major_code), XCBGetFullErrorText(err->error_code));
+#if NDEBUG
         DebugI("error_code: [%d], major_code: [%d], minor_code: [%d]\n"
               "sequence: [%d], response_type: [%d], resource_id: [%d]\n"
               "full_sequence: [%d]\n"

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -522,7 +522,7 @@ updateclientlist(XCBWindow win, uint8_t type)
     }
 
     /* if the it is equal to nothing then we have no clients add it. */
-    if(it == GArrayEnd(&_wm.clients))
+    if(it == GArrayEnd(&_wm.clients) && type != ClientListRemove)
     {   GArrayPushBack(&_wm.clients, &win);
     }
 
@@ -534,7 +534,12 @@ updateclientlist(XCBWindow win, uint8_t type)
     GArrayGetArray(&_wm.clients, &data, &size, &item_size);
     
     if(!data)
-    {   return;
+    {   
+        XCBWindow nowins = XCB_NONE;
+
+        data = &nowins;
+        item_size = sizeof(XCBWindow);
+        size = 0;
     }
 
     if(!ASSERT(item_size == sizeof(XCBWindow)))

--- a/src/prop.c
+++ b/src/prop.c
@@ -511,6 +511,9 @@ PropUpdateManage(
 
     if(c)
     {
+        /* client will be mapped so treat as so. */
+        setmapstate(c, WMMapStateMapped);
+        
         /* Dont waste extra resources if not visible */
         if(ISVISIBLE(c))
         {
@@ -520,8 +523,6 @@ PropUpdateManage(
         else
         {   showhide(c);
         }
-
-        setmapstate(c, WMMapStateMapped);
     }
     else if(_wm.selmon->bar && _wm.selmon->bar->win == win)
     {

--- a/src/settings.c
+++ b/src/settings.c
@@ -16,10 +16,6 @@
 #include "threading.h"
 #include "main.h"
 
-
-#define VOX_ADD_MEMBER_SETTING(NAME, TYPE, DEFAULT_SETTING) \
-        VOX_ADD_MEMBER(NAME, TYPE, offsetof(UserSettings, NAME), FIELD_SIZEOF(UserSettings, NAME), DEFAULT_SETTING)
-
 static const SCSetting
 __USER__SETTINGS__DATA__[] = 
 {
@@ -57,7 +53,6 @@ __USER__SETTINGS__DATA__[] =
     VOX_ADD_MEMBER_SETTING(BarBW, SCTypeFLOAT, 1.0f)    /*   bw    */
     VOX_ADD_MEMBER_SETTING(BarBH, SCTypeFLOAT, 0.15f)   /*   bh    */
 };
-
 
 void
 USSetupCFGVars(
@@ -97,7 +92,9 @@ USSetupCFGDefaults(
     UserSettings *s = us;
     void *data;
     i32 i;
+
     const SCSetting *usdata = __USER__SETTINGS__DATA__;
+
     for(i = 0; i < UserSettingsLAST; ++i)
     {
         data = ((uint8_t *)s) + usdata->offset;
@@ -264,6 +261,7 @@ USSave(
     SCParser *cfg = settings->cfg;
     UserSettings *s = settings;
     i32 i;
+
     const SCSetting *usdata = __USER__SETTINGS__DATA__;
 
     for(i = 0; i < UserSettingsLAST; ++i)

--- a/src/toggle.c
+++ b/src/toggle.c
@@ -97,6 +97,7 @@ UserStats(const Arg *arg)
         Debug("MAP ICONIC:          %s", GET_BOOL(ISMAPICONIC(c)));
         Debug("FLOATING:            %s", GET_BOOL(ISFLOATING(c)));
         Debug("WASFLOATING:         %s", GET_BOOL(WASFLOATING(c)));
+
         if(c->icon)
         {
             u32 *icon = c->icon;
@@ -829,6 +830,7 @@ SpawnWindow(const Arg *arg)
     int err;
 
     pid_t child;
+
     if(pipe(pipefds))
     {   
         perror("pipe");
@@ -836,6 +838,7 @@ SpawnWindow(const Arg *arg)
         err = EX_OSERR;
         return;
     }
+
     if(fcntl(pipefds[1], F_SETFD, fcntl(pipefds[1], F_GETFD) | FD_CLOEXEC))
     {
         perror("fcntl");
@@ -855,6 +858,7 @@ SpawnWindow(const Arg *arg)
             break;
         case 0:
             close(pipefds[0]);
+
             if (_wm.dpy)
             {   close(XCBConnectionNumber(_wm.dpy));
             }
@@ -863,6 +867,23 @@ SpawnWindow(const Arg *arg)
             {   
                 perror("setsid");
                 _exit(EXIT_FAILURE);
+            }
+
+            pid_t pid2 = fork();
+
+            /* these 2 if's are to spawn a grandchild and mostly just to prevent vox-wm from
+             * being the 'parent' of all sub process, however this is mostly a visual trick,
+             * in the process table in linux, as we already detach with close() sigaction etc...
+             * so this can fail and we dont care.
+             */
+            if(pid2 < 0)
+            {
+                perror("fork");
+                Debug0("fork() failed preventing child's appearing under the window manager, ignoring...");
+            }
+            /* exit parent process */
+            else if(pid2 > 0)
+            {   _exit(EXIT_SUCCESS);
             }
 
             close(STDIN_FILENO);
@@ -880,8 +901,11 @@ SpawnWindow(const Arg *arg)
             setpgid(0, 0);
 
             execvp(((char **)arg->v)[0], (char **)arg->v);
+
             Debug0("execvp() failed.");
+
             write(pipefds[1], &errno, sizeof(int));
+
             _exit(EXIT_SUCCESS);
             break;
         default:


### PR DESCRIPTION
- Fixed a bug where updateclientlist() would incorrectly have one window in its list when quiting all windows
- Fixed a bug where NetClientListStacking would incorrectly replace clients with XCB_NONE or 0. When it should have set its list to 0,
- Fixed a bug where NetClientList would incorrectly... just see the above line.
- setmapstate() and ISMAPPED() have been reinstated temporarily... while we try and see what optimizations we can do with it.
- Fixed option -v and --version incorrectly assuming GCC/clang extensions in implementation.
- util.h Added GET_BYTE_ORDER() function to remedy the above.
- Fixed a bug where NetActiveWindow was deleted instead of set to XCB_NONE.
- Added feature where clients are no parented by the window manager (visual fix)
- Fixed a implementation error where xerror was not set on non-debug builds.
- Fixed a implementation error where xerror would not show DebugI messages